### PR TITLE
Add db_instance_backup_enabled + rds_storage_encrypted Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,10 @@ If you need a rule that is currently not included in this module please open a P
 | config_logs_bucket | The S3 bucket for AWS Config logs. | string | - | yes |
 | config_logs_prefix | The S3 prefix for AWS Config logs. | string | `config` | no |
 | config_max_execution_frequency | The maximum frequency with which AWS Config runs evaluations for a rule. | string | `TwentyFour_Hours` | no |
+| db_backup_preferred_backup_window | For `db_instance_backup_enabled` rule. time range in which backups are created | string | `` | no |
+| db_backup_read_replicas | For `db_instance_backup_enabled` rule. Evaluates whether backups are enabled for read replicas | string | `` | no |
+| db_backup_retention_period | For `db_instance_backup_enabled` rule. The minimum retention period for backups | string | `` | no |
+| db_instance_backup_enabled | `MANAGEMENT` `RDS` Enable [this](https://docs.aws.amazon.com/config/latest/developerguide/db-instance-backup-enabled.html) rule. | string | `0` | no |
 | desired_instance_type | `MANAGEMENT` `EC2` Enable [this](https://docs.aws.amazon.com/config/latest/developerguide/desired-instance-type.html) rule. | string | `0` | no |
 | desired_instance_types | For `desired_instance_types` rule. Comma-separated list of EC2 instance types (for example, "t2.small, m4.large, i2.xlarge"). | string | `` | no |
 | ebs_optimized_instance | `PERFORMANCE` `EC2` `EBS` Enable [this](https://docs.aws.amazon.com/config/latest/developerguide/ebs-optimized-instance.html) rule. | string | `0` | no |

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ If you need a rule that is currently not included in this module please open a P
 | password_require_uppercase | For `iam_password_policy` rule. Require at least one uppercase character in password. | string | `true` | no |
 | password_reuse_prevention | For `iam_password_policy` rule. For `iam_password_policy` rule. Number of passwords before allowing reuse. | string | `24` | no |
 | rds_multi_az_support | `AVAILABILITY` `RDS` Enable [this](https://docs.aws.amazon.com/config/latest/developerguide/rds-multi-az-support.html) rule. | string | `0` | no |
+| rds_storage_encrypted | `SECURITY` `RDS` Enable [this](https://docs.aws.amazon.com/config/latest/developerguide/rds-storage-encrypted.html) rule. | string | `0` | no |
 | required_tag_key_1 | For `required_tags` rule. Required Tag 1 | string | `` | no |
 | required_tag_key_2 | For `required_tags` rule. Required Tag 2 | string | `` | no |
 | required_tag_key_3 | For `required_tags` rule. Required Tag 3 | string | `` | no |

--- a/config-policies/db-instance-backup-enabled.tpl
+++ b/config-policies/db-instance-backup-enabled.tpl
@@ -1,5 +1,12 @@
 {
-	"backupRetentionPeriod": "${backup_retention_period}",
-	"preferredBackupWindow": "${preferred_backup_window}",
-	"checkReadReplicas" : "${check_read_replicas}"
+    ${join(
+        ",",
+        compact(
+            list(
+                backup_retention_period == "" ? "" : format("\"backupRetentionPeriod\": \"%s\"",backup_retention_period),
+                preferred_backup_window == "" ? "" : format("\"preferredBackupWindow\": \"%s\"",preferred_backup_window),
+                check_read_replicas == "" ? "" : format("\"checkReadReplicas\": \"%s\"",check_read_replicas),
+            )
+        )
+    )}
 }

--- a/config-policies/db-instance-backup-enabled.tpl
+++ b/config-policies/db-instance-backup-enabled.tpl
@@ -1,0 +1,5 @@
+{
+	"backupRetentionPeriod": "${backup_retention_period}",
+	"preferredBackupWindow": "${preferred_backup_window}",
+	"checkReadReplicas" : "${check_read_replicas}"
+}

--- a/config-rules-management.variables.tf
+++ b/config-rules-management.variables.tf
@@ -127,3 +127,24 @@ variable "ec2_platform_check_agent_version" {
   description = "For `ec2_platform_check_platform_type` rule. The version of the agent (for example, \"2.0.433.0\")."
   default     = ""
 }
+
+variable "db_instance_backup_enabled" {
+  description = "`MANAGEMENT` `RDS` Enable [this](https://docs.aws.amazon.com/config/latest/developerguide/db-instance-backup-enabled.html) rule."
+  description = "For `db_instance_backup_enabled` rule. The version of the agent (for example, \"2.0.433.0\")."
+  default     = 0
+}
+
+variable "db_backup_retention_period" {
+  description = "For `db_instance_backup_enabled` rule. The minimum retention period for backups"
+  default     = ""
+}
+
+variable "db_backup_preferred_backup_window" {
+  description = "For `db_instance_backup_enabled` rule. time range in which backups are created"
+  default     = ""
+}
+
+variable "db_backup_read_replicas" {
+  description = "For `db_instance_backup_enabled` rule. Evaluates whether backups are enabled for read replicas"
+  default     = ""
+}

--- a/config-rules-security.tf
+++ b/config-rules-security.tf
@@ -177,6 +177,22 @@ resource "aws_config_config_rule" "encrypted_volumes" {
   ]
 }
 
+resource "aws_config_config_rule" "rds_storage_encrypted" {
+  name        = "rds_storage_encrypted"
+  description = "[SECURITY] [RDS] Checks whether storage encryption is enabled for your RDS DB instances."
+  count       = "${var.rds_storage_encrypted}"
+
+  source {
+    owner             = "AWS"
+    source_identifier = "RDS_STORAGE_ENCRYPTED"
+  }
+
+  depends_on = [
+    "aws_config_configuration_recorder.main",
+    "aws_config_delivery_channel.main",
+  ]
+}
+
 resource "aws_config_config_rule" "restricted_ssh" {
   name        = "restricted_ssh"
   description = "[SECURITY] [EC2] [SSH]Checks whether security groups in use do not allow restricted incoming SSH traffic. This rule applies only to IPv4."

--- a/config-rules-security.tf
+++ b/config-rules-security.tf
@@ -163,7 +163,7 @@ resource "aws_config_config_rule" "elb_acm_certificate_required" {
 
 resource "aws_config_config_rule" "encrypted_volumes" {
   name        = "encrypted_volumes"
-  description = "[SECURITY] [EC2] [EBS] Checks whether the EBS volumes that are in an attached state are encrypted. If you specify the ID of a KMS key for encryption using the kmsId parameter, the rule checks if the EBS volumes in an attached state are encrypted with that KMS key."
+  description = "[SECURITY] [EC2] [EBS] Checks whether the EBS volumes that are in an attached state are encrypted."
   count       = "${var.encrypted_volumes}"
 
   source {

--- a/config-rules-security.variables.tf
+++ b/config-rules-security.variables.tf
@@ -88,6 +88,11 @@ variable "encrypted_volumes" {
   default     = 0
 }
 
+variable "rds_storage_encrypted" {
+  description = "`SECURITY` `RDS` Enable [this](https://docs.aws.amazon.com/config/latest/developerguide/rds-storage-encrypted.html) rule."
+  default     = 0
+}
+
 variable "restricted_ssh" {
   description = "`SECURITY` `EC2` `SSH` Enable [this](https://docs.aws.amazon.com/config/latest/developerguide/restricted-ssh.html) rule."
   default     = 0


### PR DESCRIPTION
I know this is a pull request to the main repo, but as that is still pending, i added some more rules. 
I also fixed the description for `encrypted_volumes` as it was >256 chars and AWS complains for that. 